### PR TITLE
Fix: Ensure timer stops and displays correctly on game completion

### DIFF
--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -89,16 +89,26 @@ export const GameBoard = () => {
       const secondCard = gameState.cards.find((card) => card.id === secondId);
 
       if (firstCard?.image === secondCard?.image && firstId !== secondId) {
-        setGameState((prev) => ({
-          ...prev,
-          cards: prev.cards.map((card) =>
+        setGameState((prev) => {
+          const newCards = prev.cards.map((card) =>
             card.id === firstId || card.id === secondId
               ? { ...card, isMatched: true }
               : card
-          ),
-          score: prev.score + 10,
-        }));
-        toast.success("Match found!");
+          );
+          return {
+            ...prev,
+            cards: newCards,
+            score: prev.score + 10,
+          };
+        }, (newState) => {
+          // newState is the state after the above update
+          toast.success("Match found!");
+          const allCardsMatched = newState.cards.every(card => card.isMatched);
+          if (allCardsMatched) {
+            setGameState(prev => ({ ...prev, isGameOver: true }));
+            toast.success("Congratulations! You've matched all pairs!");
+          }
+        });
       } else {
         setTimeout(() => {
           setGameState((prev) => ({
@@ -170,6 +180,7 @@ export const GameBoard = () => {
               gameMode={gameState.gameMode}
               onTimeUp={gameOver}
               gameStarted={gameStarted}
+              isGameOver={gameState.isGameOver}
             />
           </motion.div>
         </div>

--- a/src/components/game/Timer.tsx
+++ b/src/components/game/Timer.tsx
@@ -7,13 +7,14 @@ interface TimerProps {
   gameMode: GameMode;
   onTimeUp: () => void;
   gameStarted: boolean;
+  isGameOver: boolean;
 }
 
-export const Timer = ({ initialTime, gameMode, onTimeUp, gameStarted }: TimerProps) => {
+export const Timer = ({ initialTime, gameMode, onTimeUp, gameStarted, isGameOver }: TimerProps) => {
   const [timeLeft, setTimeLeft] = useState(initialTime);
 
   useEffect(() => {
-    if (!gameStarted || gameMode !== "timeAttack") return;
+    if (!gameStarted || gameMode !== "timeAttack" || isGameOver) return;
 
     const timer = setInterval(() => {
       setTimeLeft((prev) => {
@@ -27,7 +28,7 @@ export const Timer = ({ initialTime, gameMode, onTimeUp, gameStarted }: TimerPro
     }, 1000);
 
     return () => clearInterval(timer);
-  }, [gameMode, onTimeUp, gameStarted]);
+  }, [gameMode, onTimeUp, gameStarted, isGameOver]);
 
   return (
     <span className="font-mono font-semibold">


### PR DESCRIPTION
The timer in the memory card game was not behaving as expected when the game finished by matching all cards, potentially continuing to run or not displaying the correct final time.

This commit addresses the issue by:
1. Introducing an `isGameOver` prop to the `Timer` component.
2. Modifying the `Timer` component to clear its interval and thus stop updating its `timeLeft` state when `isGameOver` becomes true. This ensures the timer freezes, displaying the time at which the game ended.
3. Updating `GameBoard` to set `isGameOver` to true not only when the time runs out but also when all card pairs have been successfully matched.
4. Passing the `isGameOver` state from `GameBoard` to the `Timer`.

These changes ensure that the timer accurately reflects the game's end state, whether you win by matching all cards or the time expires.